### PR TITLE
feat: add credential issuer contract with extended metadata buffer

### DIFF
--- a/certchain/contracts/credential-issuer.clar
+++ b/certchain/contracts/credential-issuer.clar
@@ -1,0 +1,70 @@
+;; Credential Issuer Contract for CertiChain
+
+(define-trait institution-registry-trait
+  (
+    (is-verified-institution (principal) (response bool uint))
+  )
+)
+
+(define-constant ERR-NOT-AUTHORIZED u100)
+(define-constant ERR-NOT-VERIFIED u101)
+(define-constant ERR-NOT-FOUND u102)
+
+(define-data-var credential-counter uint u0)
+
+(define-map credentials
+  uint
+  {
+    issuer: principal,
+    student: principal,
+    metadata: (buff 1024),
+    active: bool
+  }
+)
+
+(define-constant institution-registry 'ST000000000000000000002AMW42H.institution-registry) ;; replace with actual address
+
+;; Public: Issue credential
+(define-public (issue-credential (student principal) (metadata (buff 1024)))
+  (begin
+    (let ((verified (contract-call? institution-registry is-verified-institution tx-sender)))
+      (match verified
+        true
+          (let ((id (+ (var-get credential-counter) u1)))
+            (map-set credentials id {
+              issuer: tx-sender,
+              student: student,
+              metadata: metadata,
+              active: true
+            })
+            (var-set credential-counter id)
+            (ok id)
+          )
+        false (err ERR-NOT-VERIFIED)
+      )
+    )
+  )
+)
+
+;; Public: Revoke credential
+(define-public (revoke-credential (id uint))
+  (begin
+    (match (map-get? credentials id)
+      credential
+        (begin
+          (asserts! (is-eq tx-sender (get issuer credential)) (err ERR-NOT-AUTHORIZED))
+          (map-set credentials id (merge credential { active: false }))
+          (ok true)
+        )
+      none (err ERR-NOT-FOUND)
+    )
+  )
+)
+
+;; Read-only: Get credential details
+(define-read-only (get-credential (id uint))
+  (match (map-get? credentials id)
+    credential (ok credential)
+    none (err ERR-NOT-FOUND)
+  )
+)

--- a/certchain/tests/credential-issuer.test.ts
+++ b/certchain/tests/credential-issuer.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach } from "vitest"
+
+const mockCredentialIssuer = {
+  institutionRegistry: {
+    verified: new Set<string>(),
+
+    isVerifiedInstitution(principal: string) {
+      return this.verified.has(principal)
+    }
+  },
+
+  credentialCounter: 0,
+  credentials: new Map<number, any>(),
+
+  issueCredential(sender: string, student: string, metadata: string) {
+    if (!this.institutionRegistry.isVerifiedInstitution(sender)) {
+      return { error: 101 } // ERR-NOT-VERIFIED
+    }
+
+    const id = ++this.credentialCounter
+    this.credentials.set(id, {
+      issuer: sender,
+      student,
+      metadata,
+      active: true
+    })
+
+    return { value: id }
+  },
+
+  revokeCredential(sender: string, id: number) {
+    const credential = this.credentials.get(id)
+    if (!credential) return { error: 102 } // ERR-NOT-FOUND
+    if (credential.issuer !== sender) return { error: 100 } // ERR-NOT-AUTHORIZED
+
+    credential.active = false
+    this.credentials.set(id, credential)
+    return { value: true }
+  },
+
+  getCredential(id: number) {
+    const credential = this.credentials.get(id)
+    if (!credential) return { error: 102 }
+    return { value: credential }
+  }
+}
+
+describe("Credential Issuer Contract", () => {
+  beforeEach(() => {
+    mockCredentialIssuer.credentialCounter = 0
+    mockCredentialIssuer.credentials = new Map()
+    mockCredentialIssuer.institutionRegistry.verified = new Set([
+      "ST1INSTITUTION"
+    ])
+  })
+
+  it("should allow verified institution to issue credential", () => {
+    const result = mockCredentialIssuer.issueCredential(
+      "ST1INSTITUTION",
+      "STUDENT1",
+      "Bachelor of Blockchain Engineering"
+    )
+    expect(result).toHaveProperty("value", 1)
+
+    const stored = mockCredentialIssuer.getCredential(1)
+    expect(stored.value).toMatchObject({
+      issuer: "ST1INSTITUTION",
+      student: "STUDENT1",
+      metadata: "Bachelor of Blockchain Engineering",
+      active: true
+    })
+  })
+
+  it("should prevent unverified institution from issuing", () => {
+    const result = mockCredentialIssuer.issueCredential(
+      "ST3UNVERIFIED",
+      "STUDENT2",
+      "Fake Degree"
+    )
+    expect(result).toEqual({ error: 101 })
+  })
+
+  it("should allow issuer to revoke their credential", () => {
+    mockCredentialIssuer.issueCredential(
+      "ST1INSTITUTION",
+      "STUDENT3",
+      "Masters in Crypto"
+    )
+    const revoke = mockCredentialIssuer.revokeCredential("ST1INSTITUTION", 1)
+    expect(revoke).toEqual({ value: true })
+
+    const credential = mockCredentialIssuer.getCredential(1)
+    expect(credential.value.active).toBe(false)
+  })
+
+  it("should prevent others from revoking credential", () => {
+    mockCredentialIssuer.issueCredential(
+      "ST1INSTITUTION",
+      "STUDENT4",
+      "PhD in Solidity"
+    )
+    const revoke = mockCredentialIssuer.revokeCredential("ST4RANDOM", 1)
+    expect(revoke).toEqual({ error: 100 })
+  })
+
+  it("should return error when revoking nonexistent credential", () => {
+    const result = mockCredentialIssuer.revokeCredential("ST1INSTITUTION", 999)
+    expect(result).toEqual({ error: 102 })
+  })
+
+  it("should return credential details", () => {
+    mockCredentialIssuer.issueCredential(
+      "ST1INSTITUTION",
+      "STUDENT5",
+      "Certificate in DeFi"
+    )
+    const result = mockCredentialIssuer.getCredential(1)
+    expect(result.value.student).toBe("STUDENT5")
+  })
+
+  it("should error on unknown credential ID", () => {
+    const result = mockCredentialIssuer.getCredential(999)
+    expect(result).toEqual({ error: 102 })
+  })
+})


### PR DESCRIPTION
Implements the `credential-issuer.clar` smart contract for issuing and revoking academic credentials. This version supports longer credential metadata (up to 1024 bytes) to allow rich data such as full credential descriptions, hashes, or references to off-chain storage.

## Changes

- ✅ Added `credential-issuer.clar`
  - Allows verified institutions to issue credentials with 1024-byte metadata
  - Credentials are non-transferable and include status tracking (`active`)
  - Includes access control to ensure only the issuer can revoke
- ✅ Integrated with `institution-registry.clar` via contract-call
- ✅ Added full mock test suite in `credential-issuer.test.ts`
  - Covers issuance, revocation, error handling, and metadata integrity

## Contract Design

- Stores credentials in a map keyed by ID (`uint`)
- Uses a counter to auto-increment credential IDs
- Requires issuer verification through the institution registry
- Credential data includes: `issuer`, `student`, `metadata`, `active`

## Next Steps

- Build the credential verifier contract
- Add integration tests that simulate cross-contract calls
